### PR TITLE
Scrolling works on mobile without having to select an item first

### DIFF
--- a/src/registry/new-york/items/multi-select/components/multi-select.tsx
+++ b/src/registry/new-york/items/multi-select/components/multi-select.tsx
@@ -217,9 +217,9 @@ export function MultiSelectValue({
             onClick={
               clickToRemove
                 ? e => {
-                    e.stopPropagation()
-                    toggleValue(value)
-                  }
+                  e.stopPropagation()
+                  toggleValue(value)
+                }
                 : undefined
             }
           >
@@ -259,7 +259,21 @@ export function MultiSelectContent({
           <CommandList>{children}</CommandList>
         </Command>
       </div>
-      <PopoverContent className="min-w-[var(--radix-popover-trigger-width)] p-0">
+      <PopoverContent className="min-w-[var(--radix-popover-trigger-width)] p-0"
+        onTouchStart={e => {
+          const target = e.currentTarget;
+          if (target && typeof target.focus === "function") {
+            target.focus();
+          }
+        }}
+        onTouchMove={e => {
+          e.stopPropagation();
+        }}
+        style={{
+          WebkitOverflowScrolling: "touch",
+          overflowY: "auto",
+        }}
+        tabIndex={-1}>
         <Command {...props}>
           {canSearch ? (
             <CommandInput


### PR DESCRIPTION
## **Explanation of the Fix:**

The problem was that on mobile devices, when users try to scroll within the PopoverContent, the touch events were bubbling up to the parent container, causing the outer page to scroll instead of the popover content.  
The focus was only set after selecting an item.

## **What the solution does:**

1. **`onTouchStart` handler**: When a user starts touching the popover content, it ensures the element receives focus, making it the active target for scroll events.

2. **`onTouchMove` handler**: Prevents touch move events from bubbling up to parent containers by calling `e.stopPropagation()`, ensuring scroll gestures stay within the popover.

3. **`WebkitOverflowScrolling: 'touch'`**: Enables smooth momentum-based scrolling on iOS devices.

4. **`overflowY: 'auto'`**: Ensures the content is scrollable when it overflows vertically.

5. **`tabIndex={-1}`**: Makes the element focusable programmatically without adding it to the tab order. Users should tab to interactive elements inside the popover (like the search input and options), not to the popover container itself.
