### PR TITLE
Fix-Multi Select on duplicate labels

### DIFF
--- a/src/registry/new-york/items/multi-select/components/multi-select.tsx
+++ b/src/registry/new-york/items/multi-select/components/multi-select.tsx
@@ -305,6 +305,7 @@ export function MultiSelectItem({
   return (
     <CommandItem
       {...props}
+      value={value}
       onSelect={() => {
         toggleValue(value)
         onSelect?.(value)


### PR DESCRIPTION
### Problem
when you use a set of options with the same labels (childrens) inside multi select, for example: 
```
const items = [{ label: "item 1", value: 1}, { label: "item 1", value: 2}]
```
In `multiSelectItem` it forgot to apply the value to the command component therefore the `command` components sets children as its value and it would ruin the selected state as the [selected=true] would complicates styling in tailwind.