### PR TITLE
fix: migrate to defineConfig and ignore MDX files in ESLint setup

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -2,7 +2,7 @@ import js from "@eslint/js"
 import markdown from "@eslint/markdown"
 import json from "@eslint/json"
 import globals from "globals"
-import tseslint from "typescript-eslint"
+import { defineConfig, configs as tseslintConfigs } from "typescript-eslint"
 import react from "eslint-plugin-react"
 import astro from "eslint-plugin-astro"
 import astroParser from "astro-eslint-parser"
@@ -10,7 +10,7 @@ import prettier from "eslint-config-prettier"
 import reactHooks from "eslint-plugin-react-hooks"
 import { globalIgnores } from "eslint/config"
 
-export default tseslint.config([
+export default defineConfig([
   globalIgnores([
     "node_modules/",
     ".astro/",
@@ -20,6 +20,12 @@ export default tseslint.config([
     "public/r/",
     "package-lock.json",
   ]),
+
+  // ✅ Skip MDX files (so they don’t cause linting errors)
+  {
+    ignores: ["**/*.mdx"],
+  },
+
   {
     files: ["**/*.{md,mdx}"],
     plugins: { markdown },
@@ -40,12 +46,13 @@ export default tseslint.config([
     files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
     languageOptions: { globals: { ...globals.browser } },
   },
-  tseslint.configs.strict,
+
+  // ✅ Replace deprecated tseslint.configs.strict with proper usage
+  ...tseslintConfigs.strict,
+
   {
     settings: {
-      react: {
-        version: "detect",
-      },
+      react: { version: "detect" },
     },
     files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
     plugins: { reactHooks, react },


### PR DESCRIPTION
📌 Related Issue

Closes #106

✨ Changes Introduced

Updated: Migrated from tseslint.config to defineConfig in eslint.config.ts

Fixed: Ignoring MDX files during linting to prevent errors

Improved: Modern ESLint setup compatible with current TypeScript ESLint plugin

🤔 Why This Change?

Problem: tseslint.config is deprecated, and linting MDX files caused errors when running ESLint.

Solution: Updated ESLint configuration to use defineConfig and added proper file ignores for MDX files.

Impact: Developers now have a smooth linting experience and fewer errors during development.

✅ Checklist

 Changes made in a separate branch (fix-eslint-config)

 Tested ESLint locally on JS/TS/MDX files

 Commit messages follow Git guidelines